### PR TITLE
TotalSize column type change from string to double in order to be able to order for memory usage investigation

### DIFF
--- a/scripts/ClrMD_Dump.linq
+++ b/scripts/ClrMD_Dump.linq
@@ -59,7 +59,9 @@ public static class LocalExtensions
             {
                 Type = typeGroup.Key.Name,
                 Count = count,
-                TotalSize = (totalSize / 1024 / 1024).ToString("0.## MB"),
+                // TotalSizeMB would be easier to use because its is a double value
+				// which we can use to order to investigate on memory usage
+                TotalSizeMB = (totalSize / 1024 / 1024),
                 // Get the first 100 instances of the type.
                 First100Objects = typeGroup.Take(100),
             }


### PR DESCRIPTION
TotalSizeMB would be easier to use because its is a double value which
we can use to order to investigate on memory usage.
