### PR TITLE
Add DowncastToBase and update EnumerateClrObjects

### DIFF
--- a/ClrMD.Extensions/ClrMDExtensions.cs
+++ b/ClrMD.Extensions/ClrMDExtensions.cs
@@ -85,6 +85,11 @@ namespace ClrMD.Extensions
                    select new ClrObject(address, type);
         }
 
+        public static ClrObject DowncastToBase(this ClrObject clrObject)
+        {
+            return clrObject?.Type?.BaseType != null ? new ClrObject(clrObject.Address, clrObject.Type.BaseType) : null;
+        }
+
         public static IEnumerable<ClrObject> EnumerateClrObjects(this ClrHeap heap, params string[] typeNames)
         {
             return heap.EnumerateClrObjects((IEnumerable<string>)typeNames);

--- a/ClrMD.Extensions/ClrMDExtensions.cs
+++ b/ClrMD.Extensions/ClrMDExtensions.cs
@@ -85,11 +85,6 @@ namespace ClrMD.Extensions
                    select new ClrObject(address, type);
         }
 
-        public static ClrObject DowncastToBase(this ClrObject clrObject)
-        {
-            return clrObject?.Type?.BaseType != null ? new ClrObject(clrObject.Address, clrObject.Type.BaseType) : null;
-        }
-
         public static IEnumerable<ClrObject> EnumerateClrObjects(this ClrHeap heap, params string[] typeNames)
         {
             return heap.EnumerateClrObjects((IEnumerable<string>)typeNames);
@@ -114,6 +109,11 @@ namespace ClrMD.Extensions
                    let type = heap.GetSafeObjectType(address)
                    where type != null && set.Contains(type.Name)
                    select new ClrObject(address, type);
+        }
+
+        public static ClrObject DowncastToBase(this ClrObject clrObject)
+        {
+            return clrObject?.Type?.BaseType != null ? new ClrObject(clrObject.Address, clrObject.Type.BaseType) : null;
         }
 
         public class StackFrameInfo

--- a/ClrMD.Extensions/ClrMDSession.cs
+++ b/ClrMD.Extensions/ClrMDSession.cs
@@ -166,15 +166,13 @@ namespace ClrMD.Extensions
         {
             if (typeName.Contains("*"))
             {
-                string typeNameRegex = "^" + Regex.Escape(typeName).Replace("\\*", ".*") + "$";
-                Regex regex = new Regex(typeNameRegex, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                var regex = new Regex($"^{Regex.Escape(typeName).Replace("\\*", ".*")}$",
+                    RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-                return AllObjects.Where(item => regex.IsMatch(item.Type.Name));
+                return AllObjects.Where(item => regex.IsMatch(item.TypeName));
             }
 
-            typeName = ObfuscateType(typeName);
-
-            return AllObjects.Where(item => item.Type.Name == typeName);
+            return AllObjects.Where(item => item.TypeName == typeName);
         }
 
         public void CreateReferenceMapping()


### PR DESCRIPTION
Add DowncastToBase and support for wildcard type search in EnumerateClrObjects when dealing with obfuscated code.
