### PR TITLE
Avoid throwing a NullReferenceException when GetSimpleValue is called on a null ClrObject

### DIFF
--- a/ClrMD.Extensions/ClrObject.cs
+++ b/ClrMD.Extensions/ClrObject.cs
@@ -602,7 +602,7 @@ namespace ClrMD.Extensions
             public static object GetSimpleValue(ClrObject obj)
             {
                 if (obj.IsNull())
-                    throw new NullReferenceException("ClrObject at is pointing to null address.");
+                    return null;
 
                 ClrType type = obj.Type;
                 ClrHeap heap = type.Heap;


### PR DESCRIPTION
Avoid throwing a NullReferenceException when GetSimpleValue is called on a null ClrObject, instead simply return null. This allows for proper operation of comparison operator or cast operator on Dynamic properties. For instance  'clrObject.Dynamic.m_Name == "FooBar"' would have previously failed to complete if m_Name was null.
