### PR TITLE
Add an enumerator for Dictionary values

### DIFF
--- a/ClrMD.Extensions/ClrObject.cs
+++ b/ClrMD.Extensions/ClrObject.cs
@@ -243,6 +243,28 @@ namespace ClrMD.Extensions
             return references;
         }
 
+        public IEnumerable<ClrObject> EnumerateDictionaryValues()
+        {
+            if (!TypeName.StartsWith("System.Collections.Generic.Dictionary<"))
+                yield break;
+
+            // https://referencesource.microsoft.com/#mscorlib/system/collections/generic/dictionary.cs,d864a2277aad4ece
+            var entries = this["entries"];
+            var count = (int)this["count"];
+            int index = 0;
+
+            // Use unsigned comparison since we set index to dictionary.count+1 when the enumeration ends.
+            // dictionary.count+1 could be negative if dictionary.count is Int32.MaxValue
+            while ((uint)index < (uint)count)
+            {
+                if ((int)entries[index]["hashCode"] >= 0)
+                {
+                    yield return entries[index]["value"];
+                    index++;
+                }
+            }
+        }
+
         private ClrObject GetInnerObject(ulong pointer, ClrType type)
         {
             ulong fieldAddress;


### PR DESCRIPTION
I added a method on a ClrObject that allows to enumerate the child values when the object is a generic dictionary. This can be very helpful when debugging a crash dump where each object has dictionaries and we want to get its content.