### PR TITLE
Changed ClrMDSession.AllObject to a segmented collection

### DIFF
--- a/ClrMD.Extensions/ClrMD.Extensions.csproj
+++ b/ClrMD.Extensions/ClrMD.Extensions.csproj
@@ -52,6 +52,7 @@
     <Compile Include="ClrMDExtensions.cs" />
     <Compile Include="ClrMDSession.cs" />
     <Compile Include="ClrDynamic.cs" />
+    <Compile Include="Core\ReadOnlySegmentedCollection.cs" />
     <Compile Include="LINQPad\ICustomMemberProvider.cs" />
     <Compile Include="LINQPad\LinqPadExtensions.cs" />
     <Compile Include="Obfuscation\Deobfuscator.cs" />

--- a/ClrMD.Extensions/Core/ReadOnlySegmentedCollection.cs
+++ b/ClrMD.Extensions/Core/ReadOnlySegmentedCollection.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ClrMD.Extensions.Core
+{
+    public class ReadOnlySegmentedCollection<T> : IReadOnlyCollection<T>
+    {
+        private const int SegmentSize = 4096;
+    
+        private readonly LinkedList<T[]> m_segments;
+    
+        public int Count { get; }
+    
+        public ReadOnlySegmentedCollection(IEnumerable<T> items)
+        {
+            m_segments = new LinkedList<T[]>();
+
+            T[] segment = new T[SegmentSize];
+            int i = 0;
+
+            using (var enumerator = items.GetEnumerator())
+            {
+                while (enumerator.MoveNext())
+                {
+                    ++Count;
+                    segment[i++] = enumerator.Current;
+
+                    if (i == SegmentSize)
+                    {
+                        m_segments.AddLast(segment);
+
+                        segment = new T[SegmentSize];
+                        i = 0;
+                    }
+                }
+            }
+
+            if (i > 0)
+            {
+                Array.Resize(ref segment, i);
+                m_segments.AddLast(segment);
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            foreach (var segment in m_segments)
+            {
+                for (int i = 0; i < segment.Length; i++)
+                    yield return segment[i];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
ClrMDSession.AllObjects caused OutOfMemoryCollection when a dump had more than 134 million objects.

The property is now backed by a SegmentedReadOnlyCollection