### PR TITLE
TypeName struct now supports array types properly

### DIFF
--- a/ClrMD.Extensions/Obfuscation/TypeName.cs
+++ b/ClrMD.Extensions/Obfuscation/TypeName.cs
@@ -8,33 +8,33 @@ namespace ClrMD.Extensions.Obfuscation
 
         public string Name { get; }
 
-        public bool IsArray { get; }
+        public string ArrayDefinition{ get; }
 
         public IReadOnlyList<TypeName> GenericArgs => m_genericArgs;
 
         public TypeName(string name) : this()
         {
             Name = name;
-            IsArray = false;
+            ArrayDefinition = null;
         }
 
         public TypeName(string name, params TypeName[] genericArgs)
         {
             Name = name;
-            IsArray = false;
+            ArrayDefinition = null;
             m_genericArgs = genericArgs;
         }
 
-        public TypeName(string name, bool array) : this()
+        public TypeName(string name, string array) : this()
         {
             Name = name;
-            IsArray = array;
+            ArrayDefinition = array;
         }
 
-        public TypeName(string name, bool array, params TypeName[] genericArgs)
+        public TypeName(string name, string array, params TypeName[] genericArgs)
         {
             Name = name;
-            IsArray = array;
+            ArrayDefinition = array;
             m_genericArgs = genericArgs;
         }
 
@@ -50,9 +50,9 @@ namespace ClrMD.Extensions.Obfuscation
                 s = $"{Name}<{string.Join(",", GenericArgs)}>";
             }
 
-            if (IsArray)
+            if (ArrayDefinition != null)
             {
-                s += "[]";
+                s += ArrayDefinition;
             }
             return s;
         }

--- a/ClrMD.Extensions/Obfuscation/TypeName.cs
+++ b/ClrMD.Extensions/Obfuscation/TypeName.cs
@@ -8,27 +8,53 @@ namespace ClrMD.Extensions.Obfuscation
 
         public string Name { get; }
 
+        public bool IsArray { get; }
+
         public IReadOnlyList<TypeName> GenericArgs => m_genericArgs;
 
         public TypeName(string name) : this()
         {
             Name = name;
+            IsArray = false;
         }
 
         public TypeName(string name, params TypeName[] genericArgs)
         {
             Name = name;
+            IsArray = false;
+            m_genericArgs = genericArgs;
+        }
+
+        public TypeName(string name, bool array) : this()
+        {
+            Name = name;
+            IsArray = array;
+        }
+
+        public TypeName(string name, bool array, params TypeName[] genericArgs)
+        {
+            Name = name;
+            IsArray = array;
             m_genericArgs = genericArgs;
         }
 
         public override string ToString()
         {
+            string s = "";
             if (GenericArgs == null || GenericArgs.Count == 0)
             {
-                return Name;
+                s = Name;
+            }
+            else
+            {
+                s = $"{Name}<{string.Join(",", GenericArgs)}>";
             }
 
-            return $"{Name}<{string.Join(",", GenericArgs)}>";
+            if (IsArray)
+            {
+                s += "[]";
+            }
+            return s;
         }
 
         public static implicit operator string(TypeName typeName)

--- a/ClrMD.Extensions/Obfuscation/TypeNameRegex.cs
+++ b/ClrMD.Extensions/Obfuscation/TypeNameRegex.cs
@@ -7,7 +7,7 @@ namespace ClrMD.Extensions.Obfuscation
 {
     internal static class TypeNameRegex
     {
-        private const string TypeDefRegex = @"(?<typeDeclaration>\w[\w\.\d\+`]*(?<genericArgs><[^<>]*(((?<Open><)[^<>]*)+((?<Close-Open>>)[^<>]*)+)*(?(Open)(?!))>)?(?<array>\[\])?)";
+        private const string TypeDefRegex = @"(?<typeDeclaration>\w[\w\.\d\+`]*(?<genericArgs><[^<>]*(((?<Open><)[^<>]*)+((?<Close-Open>>)[^<>]*)+)*(?(Open)(?!))>)?(?<array>(?:\[,*\])+)*)";
         private static readonly Regex s_typeRegex = new Regex(TypeDefRegex, RegexOptions.Compiled | RegexOptions.CultureInvariant);
         private static readonly Regex s_argumentListRegex = new Regex($"{TypeDefRegex},?", RegexOptions.Compiled | RegexOptions.CultureInvariant);
         private static readonly Regex s_callstackLineRegex = new Regex(@"\w[\w\.\d\+<>`]*\((?<args>.*)\)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -40,7 +40,6 @@ namespace ClrMD.Extensions.Obfuscation
                 }
             }
         }
-
         public static TypeName ParseType(string input)
         {
             var match = s_typeRegex.Match(input);
@@ -49,24 +48,30 @@ namespace ClrMD.Extensions.Obfuscation
                 string completeName = match.Value;
                 string typeName = completeName;
                 var genericArgs = match.Groups["genericArgs"];
-                bool isArray =  match.Groups["array"]?.Success == true;
+                string array = null;
+                var arrayGroup = match.Groups["array"];
+                if (arrayGroup?.Success == true)
+                {
+                    array = arrayGroup.Value;
+                }
                 if (genericArgs != null && genericArgs.Success)
                 {
                     typeName = completeName.Substring(0, genericArgs.Index - match.Index);
                     var args = match.Groups["genericArgs"].Value;
                     args = args.Substring(1, args.Length - 2);
-                    return new TypeName(SanitizeType(typeName), isArray, ParseArgList(args).ToArray());
+                    return new TypeName(SanitizeType(typeName), array, ParseArgList(args).ToArray());
                 }
 
-                if (isArray)
+                if (array != null)
                 {
-                    typeName = typeName.Substring(0, typeName.Length-2);
+                    typeName = typeName.Substring(0, typeName.Length - array.Length);
                 }
 
-                return new TypeName(SanitizeType(typeName), isArray);
+                return new TypeName(SanitizeType(typeName), array);
             }
             return new TypeName(input);
         }
+
      
         public static bool CouldBeNestedType(string input)
         {

--- a/ClrMD.Extensions/Obfuscation/TypeNameRegex.cs
+++ b/ClrMD.Extensions/Obfuscation/TypeNameRegex.cs
@@ -7,7 +7,7 @@ namespace ClrMD.Extensions.Obfuscation
 {
     internal static class TypeNameRegex
     {
-        private const string TypeDefRegex = @"(?<typeDeclaration>\w[\w\.\d\+`]*(?<genericArgs><[^<>]*(((?<Open><)[^<>]*)+((?<Close-Open>>)[^<>]*)+)*(?(Open)(?!))>)?)";
+        private const string TypeDefRegex = @"(?<typeDeclaration>\w[\w\.\d\+`]*(?<genericArgs><[^<>]*(((?<Open><)[^<>]*)+((?<Close-Open>>)[^<>]*)+)*(?(Open)(?!))>)?(?<array>\[\])?)";
         private static readonly Regex s_typeRegex = new Regex(TypeDefRegex, RegexOptions.Compiled | RegexOptions.CultureInvariant);
         private static readonly Regex s_argumentListRegex = new Regex($"{TypeDefRegex},?", RegexOptions.Compiled | RegexOptions.CultureInvariant);
         private static readonly Regex s_callstackLineRegex = new Regex(@"\w[\w\.\d\+<>`]*\((?<args>.*)\)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -49,15 +49,21 @@ namespace ClrMD.Extensions.Obfuscation
                 string completeName = match.Value;
                 string typeName = completeName;
                 var genericArgs = match.Groups["genericArgs"];
+                bool isArray =  match.Groups["array"]?.Success == true;
                 if (genericArgs != null && genericArgs.Success)
                 {
                     typeName = completeName.Substring(0, genericArgs.Index - match.Index);
                     var args = match.Groups["genericArgs"].Value;
                     args = args.Substring(1, args.Length - 2);
-                    return new TypeName(SanitizeType(typeName), ParseArgList(args).ToArray());
+                    return new TypeName(SanitizeType(typeName), isArray, ParseArgList(args).ToArray());
                 }
 
-                return new TypeName(SanitizeType(typeName));
+                if (isArray)
+                {
+                    typeName = typeName.Substring(0, typeName.Length-2);
+                }
+
+                return new TypeName(SanitizeType(typeName), isArray);
             }
             return new TypeName(input);
         }


### PR DESCRIPTION
Parsing was dropping all array portions of type definitions due to incorrect regex.
this has now been resolved.
