### PR TITLE
Add_core_support: add support of .net Core dump file in ClrMDSession

### DIFF
--- a/ClrMD.Extensions/ClrMDSession.cs
+++ b/ClrMD.Extensions/ClrMDSession.cs
@@ -1,5 +1,6 @@
 using ClrMD.Extensions.Core;
 using ClrMD.Extensions.Obfuscation;
+using Microsoft.Diagnostics.Runtime;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;


### PR DESCRIPTION
If I try to load dump file of core process I'll catch exception "Unable to find clr.dll module in dump file.", because core runtime use coreclr.dll.